### PR TITLE
Email revamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = {version = "1.0.117", optional = true}
 reqwest ={version =  "0.12.4", optional = true}
 
 [features]
-default = ["sendgrid"]
+default = ["sendgrid", "smtp2go"]
 sendgrid = ["dep:reqwest","dep:serde_json"]
+smtp2go = ["dep:reqwest","dep:serde_json"]
 experimental = []

--- a/src/email/error.rs
+++ b/src/email/error.rs
@@ -1,0 +1,41 @@
+use std::{env::VarError, fmt::Display};
+
+use crate::{email::TemplateId, templates::TemplateError};
+
+#[derive(Debug)]
+pub enum EmailError {
+    Serialization(serde_json::Error),
+    Http(reqwest::Error),
+    Initialization(VarError),
+    TemplateNotFound(TemplateId),
+    TemplateError(TemplateError),
+}
+
+impl Display for EmailError {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+impl From<TemplateError> for EmailError {
+    fn from(value: TemplateError) -> Self {
+        EmailError::TemplateError(value)
+    }
+}
+impl From<VarError> for EmailError {
+    fn from(value: VarError) -> Self {
+        EmailError::Initialization(value)
+    }
+}
+impl From<reqwest::Error> for EmailError {
+    fn from(value: reqwest::Error) -> Self {
+        EmailError::Http(value)
+    }
+}
+impl From<serde_json::Error> for EmailError {
+    fn from(value: serde_json::Error) -> Self {
+        EmailError::Serialization(value)
+    }
+}

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,2 +1,66 @@
+use std::collections::HashMap;
+
+use crate::{email::error::EmailError, templates};
+
+pub mod error;
 #[cfg(feature = "sendgrid")]
 pub mod sendgrid;
+
+pub type EmailAddress = str;
+
+pub struct EmailTemplate {
+    subject: String,
+    body_template: String,
+}
+type TemplateId = String;
+pub type Templates = HashMap<TemplateId, EmailTemplate>;
+
+pub trait EmailProvider {
+    fn send_email(
+        &self,
+        to: &EmailAddress,
+        subject: &str,
+        body_content: &str,
+    ) -> impl std::future::Future<Output = Result<(), EmailError>> + Send;
+}
+
+pub struct EmailClient<T: EmailProvider> {
+    provider: T,
+    templates: Templates,
+}
+
+impl<T: EmailProvider> EmailProvider for EmailClient<T> {
+    fn send_email(
+        &self,
+        to: &EmailAddress,
+        subject: &str,
+        body_content: &str,
+    ) -> impl std::future::Future<Output = Result<(), EmailError>> + Send {
+        self.provider.send_email(to, subject, body_content)
+    }
+}
+
+impl<T: EmailProvider> EmailClient<T> {
+    pub fn new(
+        provider: T,
+        templates: Templates,
+    ) -> Self {
+        Self {
+            provider,
+            templates,
+        }
+    }
+    pub async fn send_template(
+        &self,
+        to: &str,
+        template_id: &TemplateId,
+        template_params: &HashMap<String, String>,
+    ) -> Result<(), EmailError> {
+        let template = self
+            .templates
+            .get(template_id)
+            .ok_or(EmailError::TemplateNotFound(template_id.clone()))?;
+        let filled_template = templates::fill_template(&template.body_template, template_params)?;
+        self.send_email(to, &template.subject, &filled_template).await
+    }
+}

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "smtp2go")]
+mod smtp2go;
 #[cfg(feature = "sendgrid")]
 use crate::email::sendgrid::SendGridEmailClient;
+#[cfg(feature = "smtp2go")]
+use crate::email::smtp2go::Smtp2GoEmailClient;
 use crate::{email::error::EmailError, templates};
 
 pub mod error;
@@ -23,6 +27,7 @@ pub trait EmailProvider {
         to: &EmailAddress,
         subject: &str,
         body_content: &str,
+        reply_to: Option<&EmailAddress>,
     ) -> impl std::future::Future<Output = Result<(), EmailError>> + Send;
 }
 
@@ -47,6 +52,21 @@ impl EmailClient<SendGridEmailClient> {
         Ok(Self::new(provider, Default::default()))
     }
 }
+#[cfg(feature = "smtp2go")]
+impl EmailClient<Smtp2GoEmailClient> {
+    pub fn new_smtp2go(
+        api_key: String,
+        sender_email: String,
+        templates: Templates,
+    ) -> Self {
+        let provider = Smtp2GoEmailClient::new(api_key, sender_email);
+        Self::new(provider, templates)
+    }
+    pub fn smtp2go_from_env() -> Result<Self, EmailError> {
+        let provider = Smtp2GoEmailClient::from_env()?;
+        Ok(Self::new(provider, Default::default()))
+    }
+}
 
 impl<T: EmailProvider> EmailProvider for EmailClient<T> {
     fn send_email(
@@ -54,8 +74,9 @@ impl<T: EmailProvider> EmailProvider for EmailClient<T> {
         to: &EmailAddress,
         subject: &str,
         body_content: &str,
+        reply_to: Option<&EmailAddress>,
     ) -> impl std::future::Future<Output = Result<(), EmailError>> + Send {
-        self.provider.send_email(to, subject, body_content)
+        self.provider.send_email(to, subject, body_content, reply_to)
     }
 }
 
@@ -74,12 +95,13 @@ impl<T: EmailProvider> EmailClient<T> {
         to: &str,
         template_id: &TemplateId,
         template_params: &HashMap<String, String>,
+        reply_to: Option<&EmailAddress>,
     ) -> Result<(), EmailError> {
         let template = self
             .templates
             .get(template_id)
             .ok_or(EmailError::TemplateNotFound(template_id.clone()))?;
         let filled_template = templates::fill_template(&template.body_template, template_params)?;
-        self.send_email(to, &template.subject, &filled_template).await
+        self.send_email(to, &template.subject, &filled_template, reply_to).await
     }
 }

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 
+#[cfg(feature = "sendgrid")]
+use crate::email::sendgrid::SendGridEmailClient;
 use crate::{email::error::EmailError, templates};
 
 pub mod error;
 #[cfg(feature = "sendgrid")]
-pub mod sendgrid;
+mod sendgrid;
 
 pub type EmailAddress = str;
 
@@ -27,6 +29,23 @@ pub trait EmailProvider {
 pub struct EmailClient<T: EmailProvider> {
     provider: T,
     templates: Templates,
+}
+
+// ClientProviders
+#[cfg(feature = "sendgrid")]
+impl EmailClient<SendGridEmailClient> {
+    pub fn new_sendgrid(
+        api_key: String,
+        sender_email: String,
+        templates: Templates,
+    ) -> Self {
+        let provider = SendGridEmailClient::new(api_key, sender_email);
+        Self::new(provider, templates)
+    }
+    pub fn from_env() -> Result<Self, EmailError> {
+        let provider = SendGridEmailClient::from_env()?;
+        Ok(Self::new(provider, Default::default()))
+    }
 }
 
 impl<T: EmailProvider> EmailProvider for EmailClient<T> {

--- a/src/email/sendgrid.rs
+++ b/src/email/sendgrid.rs
@@ -14,6 +14,7 @@ impl EmailProvider for SendGridEmailClient {
         to: &EmailAddress,
         subject: &str,
         body_content: &str,
+        reply_to: Option<&EmailAddress>,
     ) -> Result<(), EmailError> {
         let response = reqwest::Client::new()
             // TODO: Set URL as a config / ENV variable.

--- a/src/email/sendgrid.rs
+++ b/src/email/sendgrid.rs
@@ -1,50 +1,20 @@
-use std::{collections::HashMap, env::VarError, fmt::Display};
-
 use reqwest;
 use serde::Serialize;
 
-use crate::templates::{self, TemplateError};
+use crate::email::{error::EmailError, EmailAddress, EmailProvider};
 
-pub struct EmailTemplate {
-    subject: String,
-    body_template: String,
-}
-type TemplateId = String;
-pub type Templates = HashMap<TemplateId, EmailTemplate>;
 pub struct SendGridEmailClient {
     api_key: String,
     sender_email: String,
-    templates: Templates,
 }
 
-impl SendGridEmailClient {
-    pub fn new(
-        api_key: String,
-        sender_email: String,
-        templates: Templates,
-    ) -> Self {
-        Self {
-            api_key,
-            sender_email,
-            templates,
-        }
-    }
-
-    pub fn from_env() -> Result<Self, SendGridError> {
-        let ret = Self {
-            api_key: std::env::var("SENDGRID_API_KEY")?,
-            sender_email: std::env::var("SENDGRID_SENDER_EMAIL")?,
-            templates: Default::default(),
-        };
-        Ok(ret)
-    }
-
-    pub async fn send_email(
+impl EmailProvider for SendGridEmailClient {
+    async fn send_email(
         &self,
-        to: &str,
+        to: &EmailAddress,
         subject: &str,
         body_content: &str,
-    ) -> Result<(), SendGridError> {
+    ) -> Result<(), EmailError> {
         let response = reqwest::Client::new()
             // TODO: Set URL as a config / ENV variable.
             .post("https://api.sendgrid.com/v3/mail/send")
@@ -62,19 +32,25 @@ impl SendGridEmailClient {
         response.error_for_status()?;
         Ok(())
     }
+}
 
-    pub async fn send_template(
-        &self,
-        to: &str,
-        template_id: &TemplateId,
-        template_params: &HashMap<String, String>,
-    ) -> Result<(), SendGridError> {
-        let template = self
-            .templates
-            .get(template_id)
-            .ok_or(SendGridError::TemplateNotFound(template_id.clone()))?;
-        let filled_template = templates::fill_template(&template.body_template, template_params)?;
-        self.send_email(to, &template.subject, &filled_template).await
+impl SendGridEmailClient {
+    pub fn new(
+        api_key: String,
+        sender_email: String,
+    ) -> Self {
+        Self {
+            api_key,
+            sender_email,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, EmailError> {
+        let ret = Self {
+            api_key: std::env::var("SENDGRID_API_KEY")?,
+            sender_email: std::env::var("SENDGRID_SENDER_EMAIL")?,
+        };
+        Ok(ret)
     }
 }
 
@@ -110,43 +86,6 @@ struct SendGridContent {
     #[serde(rename = "type")]
     content_type: SendGridContentType,
     value: String,
-}
-
-#[derive(Debug)]
-pub enum SendGridError {
-    Serialization(serde_json::Error),
-    Http(reqwest::Error),
-    Initialization(VarError),
-    TemplateNotFound(TemplateId),
-    TemplateError(TemplateError),
-}
-impl Display for SendGridError {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-impl From<TemplateError> for SendGridError {
-    fn from(value: TemplateError) -> Self {
-        SendGridError::TemplateError(value)
-    }
-}
-impl From<VarError> for SendGridError {
-    fn from(value: VarError) -> Self {
-        SendGridError::Initialization(value)
-    }
-}
-impl From<reqwest::Error> for SendGridError {
-    fn from(value: reqwest::Error) -> Self {
-        SendGridError::Http(value)
-    }
-}
-impl From<serde_json::Error> for SendGridError {
-    fn from(value: serde_json::Error) -> Self {
-        SendGridError::Serialization(value)
-    }
 }
 
 // Reference SendGrid API for details

--- a/src/email/smtp2go.rs
+++ b/src/email/smtp2go.rs
@@ -1,0 +1,105 @@
+use reqwest;
+use serde::Serialize;
+
+use crate::email::{error::EmailError, EmailAddress, EmailProvider};
+
+pub struct Smtp2GoEmailClient {
+    api_key: String,
+    sender_email: String,
+}
+
+impl EmailProvider for Smtp2GoEmailClient {
+    async fn send_email(
+        &self,
+        to: &EmailAddress,
+        subject: &str,
+        body_content: &str,
+        reply_to: Option<&EmailAddress>,
+    ) -> Result<(), EmailError> {
+        let mut request = Smtp2GoEmailRequest::new(
+            to.to_string(),
+            self.sender_email.to_string(),
+            subject.to_string(),
+            body_content.to_string(),
+        );
+        if let Some(reply_to) = reply_to {
+            request = request.with_header("Reply-To", reply_to);
+        }
+        let response = reqwest::Client::new()
+            // TODO: Set URL as a config / ENV variable.
+            .post("https://api.smtp2go.com/v3/email/send")
+            .header("X-Smtp2go-Api-Key", self.api_key.to_string())
+            .header("Content-Type", "application/json")
+            .body(serde_json::to_string(&request)?)
+            .send()
+            .await?;
+
+        response.error_for_status()?;
+        Ok(())
+    }
+}
+
+impl Smtp2GoEmailClient {
+    pub fn new(
+        api_key: String,
+        sender_email: String,
+    ) -> Self {
+        Self {
+            api_key,
+            sender_email,
+        }
+    }
+
+    pub fn from_env() -> Result<Self, EmailError> {
+        let ret = Self {
+            api_key: std::env::var("SMTP2GO_API_KEY")?,
+            sender_email: std::env::var("SMTP2GO_SENDER_EMAIL")?,
+        };
+        Ok(ret)
+    }
+}
+
+#[derive(Serialize)]
+struct Smtp2GoEmailRequest {
+    sender: String,
+    to: Vec<String>,
+    subject: String,
+    text_body: String,
+    custom_headers: Vec<Smtp2GoCustomHeader>,
+}
+
+// Reference Smtp2Go API for details
+impl Smtp2GoEmailRequest {
+    fn new(
+        to_email: String,
+        from_email: String,
+        subject: String,
+        email_body: String,
+    ) -> Self {
+        // Quick and dirty - TODO revamp this later
+        Smtp2GoEmailRequest {
+            sender: from_email,
+            to: vec![to_email],
+            subject,
+            text_body: email_body,
+            custom_headers: Default::default(),
+        }
+    }
+    fn with_header(
+        mut self,
+        header_name: impl ToString,
+        value: impl ToString,
+    ) -> Self {
+        self.custom_headers.push(Smtp2GoCustomHeader {
+            header: header_name.to_string(),
+            value: value.to_string(),
+        });
+        self
+    }
+}
+
+#[derive(Serialize)]
+struct Smtp2GoCustomHeader {
+    header: String,
+    value: String,
+}


### PR DESCRIPTION
Abstracts the Email sending functionality into a Triat, and implements it for SMTP2GO. Will replace sendgrid as the default service, now that SendGrid has demolished their free tier. 

I may update this trait in the future for more env-based configurations.